### PR TITLE
[codex] Publish snapshots to GitHub Packages

### DIFF
--- a/.github/workflows/gradle-master.yml
+++ b/.github/workflows/gradle-master.yml
@@ -25,6 +25,16 @@ jobs:
           SECRET_KEY_RING_BASE64: ${{ secrets.SECRET_KEY_RING_BASE64 }}
         run: |
           ./gradlew test build 
+      - name: Publish snapshot to GitHub Packages
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if grep -q '^jSuplaVersion=.*-SNAPSHOT$' gradle.properties; then
+            ./gradlew publishAllPublicationsToGitHubPackagesRepository
+          else
+            echo "Current version is not a snapshot. Skipping GitHub Packages snapshot publishing."
+          fi
   dependency-submission:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/gradle-master.yml
+++ b/.github/workflows/gradle-master.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Publish snapshot to GitHub Packages
         env:
           GITHUB_ACTOR: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PAT: ${{ secrets.PAT }}
         run: |
           if grep -q '^jSuplaVersion=.*-SNAPSHOT$' gradle.properties; then
             ./gradlew publishAllPublicationsToGitHubPackagesRepository

--- a/build.gradle
+++ b/build.gradle
@@ -155,7 +155,7 @@ prodProjects { p->
 				url = uri("https://maven.pkg.github.com/${githubRepo}")
 				credentials {
 					username = findProperty("githubPackagesUsername") ?: System.getenv("GITHUB_ACTOR")
-					password = findProperty("githubPackagesToken") ?: System.getenv("GITHUB_TOKEN")
+					password = findProperty("githubPackagesToken") ?: System.getenv("PAT")
 				}
 			}
 		}

--- a/build.gradle
+++ b/build.gradle
@@ -149,6 +149,17 @@ prodProjects { p->
 
 	def final githubRepo = "magx2/jSupla"
 	publishing {
+		repositories {
+			maven {
+				name = "GitHubPackages"
+				url = uri("https://maven.pkg.github.com/${githubRepo}")
+				credentials {
+					username = findProperty("githubPackagesUsername") ?: System.getenv("GITHUB_ACTOR")
+					password = findProperty("githubPackagesToken") ?: System.getenv("GITHUB_TOKEN")
+				}
+			}
+		}
+
 		publications {
 			mavenJava(MavenPublication) {
 				artifactId = project.name
@@ -188,6 +199,7 @@ prodProjects { p->
 	}
 
 	signing {
+		required { !version.toString().endsWith("-SNAPSHOT") }
 		sign publishing.publications.mavenJava
 	}
 }


### PR DESCRIPTION
## Summary

- Add a `GitHubPackages` Maven publishing repository for the existing `mavenJava` publications.
- Use GitHub Actions credentials (`GITHUB_ACTOR` / `GITHUB_TOKEN`) by default, with Gradle properties available for local overrides.
- Publish snapshots from the `master` workflow only when `jSuplaVersion` ends with `-SNAPSHOT`.
- Keep signing required for release versions, but not for snapshot publications.

## Validation

- `spotlessApply`
- `clean check`
- `publishAllPublicationsToGitHubPackagesRepository --dry-run`

Note: local Gradle was invoked through `GradleWrapperMain` because the checked-in `./gradlew` script has an existing quoting/path issue in this WSL shell.
