### PR TITLE
[codex] Return msg id from Supla writer

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 description=This is main project for all jSupla submodules.
-jSuplaVersion=5.1.1-SNAPSHOT
+jSuplaVersion=5.2.0-SNAPSHOT
 org.gradle.caching=true

--- a/server/src/main/java/pl/grzeslowski/jsupla/server/DefaultSuplaWriteFuture.java
+++ b/server/src/main/java/pl/grzeslowski/jsupla/server/DefaultSuplaWriteFuture.java
@@ -1,0 +1,17 @@
+package pl.grzeslowski.jsupla.server;
+
+import static java.util.Objects.requireNonNull;
+
+import io.netty.channel.ChannelFuture;
+import lombok.experimental.Delegate;
+
+record DefaultSuplaWriteFuture(long msgId, ChannelFuture delegate) implements SuplaWriteFuture {
+    DefaultSuplaWriteFuture {
+        requireNonNull(delegate);
+    }
+
+    @Delegate
+    private ChannelFuture delegateFuture() {
+        return delegate;
+    }
+}

--- a/server/src/main/java/pl/grzeslowski/jsupla/server/SuplaDefaultWriter.java
+++ b/server/src/main/java/pl/grzeslowski/jsupla/server/SuplaDefaultWriter.java
@@ -3,7 +3,6 @@ package pl.grzeslowski.jsupla.server;
 import static pl.grzeslowski.jsupla.protocol.api.consts.ProtoConsts.SUPLA_PROTO_VERSION;
 import static pl.grzeslowski.jsupla.server.NettyServer.NOISY_CALL_TYPE_IDS;
 
-import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import jakarta.annotation.Nonnull;
 import java.util.concurrent.atomic.AtomicLong;
@@ -41,16 +40,13 @@ final class SuplaDefaultWriter implements SuplaWriter {
     }
 
     @Override
-    public ChannelFuture write(@Nonnull FromServerProto proto) {
+    public SuplaWriteFuture write(@Nonnull FromServerProto proto) {
         val encoder = encoderFactory.getEncoder(proto);
         val encode = encoder.encode(proto);
+        val packetMsgId = msgId.getAndIncrement();
         val packet =
                 new SuplaDataPacket(
-                        version,
-                        msgId.getAndIncrement(),
-                        proto.callType().getValue(),
-                        encode.length,
-                        encode);
+                        version, packetMsgId, proto.callType().getValue(), encode.length, encode);
         if (NOISY_CALL_TYPE_IDS.contains(packet.callId())) {
             // log pings in trace
             LOGGER.trace(
@@ -58,6 +54,6 @@ final class SuplaDefaultWriter implements SuplaWriter {
         } else {
             LOGGER.debug("[{}] ctx.writeAndFlush({})", uuid, proto);
         }
-        return context.writeAndFlush(packet);
+        return new DefaultSuplaWriteFuture(packetMsgId, context.writeAndFlush(packet));
     }
 }

--- a/server/src/main/java/pl/grzeslowski/jsupla/server/SuplaWriteFuture.java
+++ b/server/src/main/java/pl/grzeslowski/jsupla/server/SuplaWriteFuture.java
@@ -1,0 +1,7 @@
+package pl.grzeslowski.jsupla.server;
+
+import io.netty.channel.ChannelFuture;
+
+public interface SuplaWriteFuture extends ChannelFuture {
+    long msgId();
+}

--- a/server/src/main/java/pl/grzeslowski/jsupla/server/SuplaWriter.java
+++ b/server/src/main/java/pl/grzeslowski/jsupla/server/SuplaWriter.java
@@ -1,12 +1,11 @@
 package pl.grzeslowski.jsupla.server;
 
-import io.netty.channel.ChannelFuture;
 import jakarta.annotation.Nonnull;
 import lombok.*;
 import pl.grzeslowski.jsupla.protocol.api.types.FromServerProto;
 
 public interface SuplaWriter {
-    ChannelFuture write(@Nonnull FromServerProto proto);
+    SuplaWriteFuture write(@Nonnull FromServerProto proto);
 
     short getVersion();
 }

--- a/server/src/test/java/pl/grzeslowski/jsupla/server/SuplaDefaultWriterTest.java
+++ b/server/src/test/java/pl/grzeslowski/jsupla/server/SuplaDefaultWriterTest.java
@@ -1,0 +1,76 @@
+package pl.grzeslowski.jsupla.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.DefaultChannelPromise;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import pl.grzeslowski.jsupla.protocol.api.calltypes.CallType;
+import pl.grzeslowski.jsupla.protocol.api.encoders.Encoder;
+import pl.grzeslowski.jsupla.protocol.api.encoders.EncoderFactory;
+import pl.grzeslowski.jsupla.protocol.api.structs.SuplaDataPacket;
+import pl.grzeslowski.jsupla.protocol.api.types.FromServerProto;
+import pl.grzeslowski.jsupla.protocol.api.types.ProtoWithSize;
+
+class SuplaDefaultWriterTest {
+    private static final TestProto PROTO = new TestProto(() -> 123, 3);
+    private final ChannelHandlerContext context = mock(ChannelHandlerContext.class);
+    private final SuplaDefaultWriter writer =
+            new SuplaDefaultWriter("test-uuid", new TestEncoderFactory(), context);
+
+    @Test
+    void writeShouldReturnFutureWithPacketMsgId() {
+        var channel = new EmbeddedChannel();
+        var channelFuture = new DefaultChannelPromise(channel);
+        when(context.writeAndFlush(any(SuplaDataPacket.class))).thenReturn(channelFuture);
+
+        var result = writer.write(PROTO);
+
+        var packetCaptor = ArgumentCaptor.forClass(SuplaDataPacket.class);
+        verify(context).writeAndFlush(packetCaptor.capture());
+        assertThat(result.msgId()).isEqualTo(1L);
+        assertThat(result.channel()).isSameAs(channel);
+        assertThat(packetCaptor.getValue().rrId()).isEqualTo(result.msgId());
+    }
+
+    @Test
+    void writeShouldIncrementReturnedMsgId() {
+        when(context.writeAndFlush(any(SuplaDataPacket.class)))
+                .thenReturn(mock(ChannelFuture.class), mock(ChannelFuture.class));
+
+        var first = writer.write(PROTO);
+        var second = writer.write(PROTO);
+
+        assertThat(first.msgId()).isEqualTo(1L);
+        assertThat(second.msgId()).isEqualTo(2L);
+    }
+
+    private record TestProto(CallType callType, int protoSize) implements FromServerProto {}
+
+    private static final class TestEncoderFactory implements EncoderFactory {
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T extends ProtoWithSize> Encoder<T> getEncoder(Class<T> proto) {
+            return (Encoder<T>) TestEncoder.INSTANCE;
+        }
+    }
+
+    private enum TestEncoder implements Encoder<TestProto> {
+        INSTANCE;
+
+        @Override
+        public int encode(TestProto proto, byte[] bytes, int offset) {
+            bytes[offset] = 1;
+            bytes[offset + 1] = 2;
+            bytes[offset + 2] = 3;
+            return proto.protoSize();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- return a `SuplaWriteFuture` from `SuplaWriter.write(...)`
- expose the generated packet `msgId` while preserving `ChannelFuture` behavior through Lombok delegation
- add focused tests for returned ids and packet `rrId` alignment

## Validation
- `env GRADLE_USER_HOME=/tmp/gradle-home ./gradlew --no-daemon --project-cache-dir /tmp/jsupla-gradle-project-cache :server:test`
- `env GRADLE_USER_HOME=/tmp/gradle-home ./gradlew --no-daemon --project-cache-dir /tmp/jsupla-gradle-project-cache spotlessApply`