### PR TITLE
[codex] Add product firmware update info

### DIFF
--- a/protocol/products.gradle
+++ b/protocol/products.gradle
@@ -194,7 +194,7 @@ static Object toProductCatalogEntry(Object product, Map<Integer, String> manufac
 		productId     : productId,
 		manufacturer  : findManufacturerName(manufacturerId, productName, manufacturerNames),
 		productName   : productName,
-		updatesCount  : product.updatesCount as int,
+		updatesCount     : intOrDefault(product.updatesCount, 0),
 		latestReleaseAt  : product.latestReleaseAt?.toString(),
 		latestVersion    : product.latestVersion?.toString(),
 		latestDescription: product.latestDescription?.toString(),
@@ -211,6 +211,10 @@ static String findManufacturerName(int manufacturerId, String productName, Map<I
 
 static String toManufacturerName(String constName) {
 	constName.replaceFirst(/^SUPLA_MFR_/, "").replace("_", " ")
+}
+
+static int intOrDefault(Object value, int defaultValue) {
+	value == null ? defaultValue : value as int
 }
 
 static void failOnDuplicatedProductKeys(List products) {

--- a/protocol/products.gradle
+++ b/protocol/products.gradle
@@ -58,7 +58,13 @@ task productsCatalogGenerator {
 		def productEntries = products
 			.collect { entry ->
 				"entry(new ProductKey(${entry.manufacturerId}, ${entry.productId}), " +
-					"new ProductInfo(${javaString(entry.manufacturer)}, ${javaString(entry.productName)}))"
+					"new ProductInfo(${javaString(entry.manufacturer)}, " +
+					"${javaString(entry.productName)}, " +
+					"${entry.updatesCount}, " +
+					"${javaNullableString(entry.latestReleaseAt)}, " +
+					"${javaNullableString(entry.latestVersion)}, " +
+					"${javaNullableString(entry.latestDescription)}, " +
+					"${javaNullableString(entry.productUrl)}))"
 			}
 			.join(",\n\t\t\t")
 
@@ -109,10 +115,21 @@ task productsCatalogGenerator {
 			|
 			|    public record ProductKey(int manufacturerId, int productId) {}
 			|
-			|    public record ProductInfo(String manufacturer, String name) {
+			|    public record ProductInfo(
+			|            String manufacturer,
+			|            String name,
+			|            int updatesCount,
+			|            String latestReleaseAt,
+			|            String latestVersion,
+			|            String latestDescription,
+			|            String productUrl) {
 			|        public ProductInfo {
 			|            requireNonNull(manufacturer);
 			|            requireNonNull(name);
+			|        }
+			|
+			|        public ProductInfo(String manufacturer, String name) {
+			|            this(manufacturer, name, 0, null, null, null, null);
 			|        }
 			|
 			|        public String description() {
@@ -177,6 +194,11 @@ static Object toProductCatalogEntry(Object product, Map<Integer, String> manufac
 		productId     : productId,
 		manufacturer  : findManufacturerName(manufacturerId, productName, manufacturerNames),
 		productName   : productName,
+		updatesCount  : product.updatesCount as int,
+		latestReleaseAt  : product.latestReleaseAt?.toString(),
+		latestVersion    : product.latestVersion?.toString(),
+		latestDescription: product.latestDescription?.toString(),
+		productUrl        : product.productUrl?.toString(),
 	]
 }
 
@@ -207,4 +229,8 @@ static String javaString(String value) {
 		.replace("\r", "\\r")
 		.replace("\n", "\\n")
 		.replace("\t", "\\t") + '"'
+}
+
+static String javaNullableString(String value) {
+	value == null ? "null" : javaString(value)
 }

--- a/protocol/src/test/java/pl/grzeslowski/jsupla/protocol/api/SuplaProductsTest.java
+++ b/protocol/src/test/java/pl/grzeslowski/jsupla/protocol/api/SuplaProductsTest.java
@@ -8,8 +8,39 @@ class SuplaProductsTest {
     @Test
     void shouldResolveProductByManufacturerAndProductIds() {
         assertThat(SuplaProducts.findByIds(4, 9000))
-                .hasValue(new SuplaProducts.ProductInfo("ZAMEL", "ZAMEL mSLW-01"));
+                .hasValueSatisfying(
+                        productInfo -> {
+                            assertThat(productInfo.manufacturer()).isEqualTo("ZAMEL");
+                            assertThat(productInfo.name()).isEqualTo("ZAMEL mSLW-01");
+                        });
         assertThat(SuplaProducts.describe(4, 9000)).isEqualTo("ZAMEL mSLW-01");
+    }
+
+    @Test
+    void shouldExposeFirmwareUpdateInfo() {
+        assertThat(SuplaProducts.findByIds(4, 9000))
+                .hasValueSatisfying(
+                        productInfo -> {
+                            assertThat(productInfo.updatesCount()).isPositive();
+                            assertThat(productInfo.latestReleaseAt()).isNotBlank();
+                            assertThat(productInfo.latestVersion()).isNotBlank();
+                        });
+        assertThat(
+                        SuplaProducts.SUPLA_PRODUCTS.values().stream()
+                                .anyMatch(
+                                        productInfo ->
+                                                productInfo.latestDescription() != null
+                                                        && !productInfo
+                                                                .latestDescription()
+                                                                .isBlank()))
+                .isTrue();
+        assertThat(
+                        SuplaProducts.SUPLA_PRODUCTS.values().stream()
+                                .anyMatch(
+                                        productInfo ->
+                                                productInfo.productUrl() != null
+                                                        && !productInfo.productUrl().isBlank()))
+                .isTrue();
     }
 
     @Test
@@ -25,7 +56,11 @@ class SuplaProductsTest {
     @Test
     void shouldExposeCatalogBrandName() {
         assertThat(SuplaProducts.findByIds(7, 3))
-                .hasValue(new SuplaProducts.ProductInfo("VARILIGHT", "VARILIGHT SMART SOCKET"));
+                .hasValueSatisfying(
+                        productInfo -> {
+                            assertThat(productInfo.manufacturer()).isEqualTo("VARILIGHT");
+                            assertThat(productInfo.name()).isEqualTo("VARILIGHT SMART SOCKET");
+                        });
     }
 
     @Test


### PR DESCRIPTION
## Summary
- include firmware update metadata from the SUPLA product catalog in generated ProductInfo
- preserve the existing two-argument ProductInfo constructor for compatibility
- add product catalog tests for the new metadata fields

## Validation
- ./gradlew :protocol:spotlessApply :protocol:check

## Notes
- Full ./gradlew check is currently blocked by root :spotlessMisc resolving a Windows-style gradle.properties path outside the WSL project dir.