### PR TITLE
[codex] Run tests in parallel

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,8 +92,12 @@ allProjects {
 	}
 
 	// Enable JUnit 5 (Jupiter) for all test tasks
-	tasks.withType(Test) {
+	def maxParallelTestForks =
+		(findProperty('maxParallelTestForks') ?: Math.max(1, Runtime.runtime.availableProcessors().intdiv(2))) as int
+
+	tasks.withType(Test).configureEach {
 		useJUnitPlatform()
+		maxParallelForks = maxParallelTestForks
 	}
 
 	task integrationTest(type: Test) {
@@ -103,7 +107,6 @@ allProjects {
 
 		testClassesDirs = sourceSets.integrationTest.output.classesDirs
 		classpath = sourceSets.integrationTest.runtimeClasspath
-		shouldRunAfter test
 		outputs.upToDateWhen { false }
 	}
 	check.dependsOn integrationTest

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
 description=This is main project for all jSupla submodules.
 jSuplaVersion=5.2.1-SNAPSHOT
 org.gradle.caching=true
+org.gradle.parallel=true


### PR DESCRIPTION
## Summary
- enable Gradle parallel project execution
- let all Gradle Test tasks use parallel forks, configurable with -PmaxParallelTestForks=N
- remove the unit-before-integration ordering constraint so test tasks can run concurrently

## Validation
- ./gradlew :protocol:test :protocol:integrationTest :server:test :server:integrationTest --rerun-tasks
- git diff --check -- build.gradle gradle.properties

## Notes
- Root ./gradlew check is currently blocked before tests by :spotlessMisc resolving a Windows-style path outside the WSL project directory.