### PR TITLE
[codex] Update Supla proto stable tag

### DIFF
--- a/protocol/consts.gradle
+++ b/protocol/consts.gradle
@@ -232,8 +232,9 @@ consts.each { constDef ->
 							.replaceAll(">", "&#62;")
 					}
 					def deprecated = it?.javaDoc?.contains("DEPRECATED") ? "\n\t@Deprecated" : ""
-					def suffix = constDef.options.valueType == 'long' && !it.value.contains("<") ? "L" : "" 
-					"$javaDoc$deprecated ${it.name}(${mapValue(it.value)}$suffix)"
+					def mappedValue = mapValue(it.value)
+					def suffix = constDef.options.valueType == 'long' && !it.value.contains("<") && !mappedValue.endsWith("L") ? "L" : ""
+					"$javaDoc$deprecated ${it.name}(${mappedValue}$suffix)"
 				}
 				.collect(Collectors.joining(",\n\t"))
 
@@ -460,7 +461,7 @@ static String mapValue(String value) {
 		return value.replaceAll(/(1) << (\d+)/, '1 << $2')
 	}
 	if (value.startsWith("0x")) {
-		return value
+		return needsLongHexLiteral(value) ? "${value}L" : value
 	}
 	try {
 		Eval.me(value)
@@ -486,7 +487,7 @@ static String findType(String value) {
 		return "int"
 	}
 	if (value.startsWith("0x")) {
-		return "int"
+		return needsLongHexLiteral(value) ? "long" : "int"
 	}
 	try {
 		def eval = Eval.me(value)
@@ -509,6 +510,14 @@ static String findType(String value) {
 	} catch (NumberFormatException ignored) {
 		return "String"
 	}
+}
+
+static boolean needsLongHexLiteral(String value) {
+	if (!value.startsWith("0x") && !value.startsWith("0X")) {
+		return false
+	}
+	def parsed = new BigInteger(value.substring(2), 16)
+	return parsed > BigInteger.valueOf(Integer.MAX_VALUE)
 }
 
 static boolean predefined(constObj, List overrides) {

--- a/protocol/gradle.properties
+++ b/protocol/gradle.properties
@@ -1,4 +1,4 @@
 description=This project contains classes that allows to code and decode messages send in Supla protocol.
 downloadLatestTag=master
-downloadStableTag=4ca94fc7c0d800c905947b4ee46280c8f3d4c6d0
+downloadStableTag=8cd3bbff3e020b3443e34c9d3047b0ca277ceffe
 downloadRootDir=/download

--- a/protocol/src/test/java/pl/grzeslowski/jsupla/protocol/api/ChannelFlagTest.java
+++ b/protocol/src/test/java/pl/grzeslowski/jsupla/protocol/api/ChannelFlagTest.java
@@ -1,0 +1,19 @@
+package pl.grzeslowski.jsupla.protocol.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static pl.grzeslowski.jsupla.protocol.api.ChannelFlag.SUPLA_CHANNEL_FLAG_BATTERY_COVER_AVAILABLE;
+import static pl.grzeslowski.jsupla.protocol.api.ChannelFlag.SUPLA_CHANNEL_FLAG_BUTTON_MODE_SUPPORTED;
+import static pl.grzeslowski.jsupla.protocol.api.ChannelFlag.findByMask;
+
+import org.junit.jupiter.api.Test;
+
+class ChannelFlagTest {
+    @Test
+    void findByMaskShouldNotMatchBit31FlagWhenOnlyHigherBitIsSet() {
+        var flags = findByMask(SUPLA_CHANNEL_FLAG_BUTTON_MODE_SUPPORTED.getValue());
+
+        assertThat(flags)
+                .containsExactly(SUPLA_CHANNEL_FLAG_BUTTON_MODE_SUPPORTED)
+                .doesNotContain(SUPLA_CHANNEL_FLAG_BATTERY_COVER_AVAILABLE);
+    }
+}


### PR DESCRIPTION
## Summary
- update `downloadStableTag` to SUPLA/supla-core `8cd3bbff3e020b3443e34c9d3047b0ca277ceffe` so `proto.h` matches upstream master
- make the protocol constants generator emit Java `long` hex literals when `proto.h` contains values beyond 32 bits

## Root cause
The scheduled proto update check failed because upstream `supla-common/proto.h` changed after the pinned stable tag. The new channel flag constants include hex values such as `0x100000000`, which also exposed that generated Java enum values need an `L` suffix for literals wider than 32 bits.

## Verification
- `./gradlew clean spotlessApply`
- `./gradlew checkForProtoUpdate`
- `./gradlew check`