### PR TITLE
Parse channel values by channel function

### DIFF
--- a/protocol/src/integrationTest/java/pl/grzeslowski/jsupla/protocol/api/channeltype/EncodeAndDecodeTest.java
+++ b/protocol/src/integrationTest/java/pl/grzeslowski/jsupla/protocol/api/channeltype/EncodeAndDecodeTest.java
@@ -3,6 +3,7 @@ package pl.grzeslowski.jsupla.protocol.api.channeltype;
 import static java.math.RoundingMode.HALF_UP;
 import static java.util.function.Predicate.not;
 import static org.assertj.core.api.Assertions.assertThat;
+import static pl.grzeslowski.jsupla.protocol.api.ChannelFunction.*;
 import static pl.grzeslowski.jsupla.protocol.api.ChannelType.*;
 import static pl.grzeslowski.jsupla.protocol.api.HvacFlag.*;
 
@@ -16,7 +17,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
-import pl.grzeslowski.jsupla.protocol.api.BitFunction;
+import pl.grzeslowski.jsupla.protocol.api.ChannelFunction;
 import pl.grzeslowski.jsupla.protocol.api.ChannelType;
 import pl.grzeslowski.jsupla.protocol.api.HvacFlag;
 import pl.grzeslowski.jsupla.protocol.api.HvacMode;
@@ -26,42 +27,41 @@ import pl.grzeslowski.jsupla.protocol.api.channeltype.encoders.ChannelTypeEncode
 import pl.grzeslowski.jsupla.protocol.api.channeltype.value.*;
 
 class EncodeAndDecodeTest {
-    private static final Map<Class<? extends ChannelValue>, BitFunction> SEMANTIC_RELAY_FUNCTIONS =
-            Map.ofEntries(
-                    Map.entry(
-                            GatewayLockValue.class,
-                            BitFunction.SUPLA_BIT_FUNC_CONTROLLINGTHEGATEWAYLOCK),
-                    Map.entry(GateValue.class, BitFunction.SUPLA_BIT_FUNC_CONTROLLINGTHEGATE),
-                    Map.entry(
-                            GarageDoorValue.class,
-                            BitFunction.SUPLA_BIT_FUNC_CONTROLLINGTHEGARAGEDOOR),
-                    Map.entry(
-                            DoorLockValue.class, BitFunction.SUPLA_BIT_FUNC_CONTROLLINGTHEDOORLOCK),
-                    Map.entry(
-                            RollerShutterValue.class,
-                            BitFunction.SUPLA_BIT_FUNC_CONTROLLINGTHEROLLERSHUTTER),
-                    Map.entry(PowerSwitchValue.class, BitFunction.SUPLA_BIT_FUNC_POWERSWITCH),
-                    Map.entry(LightSwitchValue.class, BitFunction.SUPLA_BIT_FUNC_LIGHTSWITCH),
-                    Map.entry(StaircaseTimerValue.class, BitFunction.SUPLA_BIT_FUNC_STAIRCASETIMER),
-                    Map.entry(
-                            RoofWindowValue.class,
-                            BitFunction.SUPLA_BIT_FUNC_CONTROLLINGTHEROOFWINDOW),
-                    Map.entry(
-                            FacadeBlindValue.class,
-                            BitFunction.SUPLA_BIT_FUNC_CONTROLLINGTHEFACADEBLIND),
-                    Map.entry(TerraceAwningValue.class, BitFunction.SUPLA_BIT_FUNC_TERRACE_AWNING),
-                    Map.entry(
-                            ProjectorScreenValue.class,
-                            BitFunction.SUPLA_BIT_FUNC_PROJECTOR_SCREEN),
-                    Map.entry(CurtainValue.class, BitFunction.SUPLA_BIT_FUNC_CURTAIN),
-                    Map.entry(VerticalBlindValue.class, BitFunction.SUPLA_BIT_FUNC_VERTICAL_BLIND),
-                    Map.entry(
-                            RollerGarageDoorValue.class,
-                            BitFunction.SUPLA_BIT_FUNC_ROLLER_GARAGE_DOOR),
-                    Map.entry(PumpSwitchValue.class, BitFunction.SUPLA_BIT_FUNC_PUMPSWITCH),
-                    Map.entry(
-                            HeatOrColdSourceSwitchValue.class,
-                            BitFunction.SUPLA_BIT_FUNC_HEATORCOLDSOURCESWITCH));
+    private static final Map<Class<? extends ChannelValue>, ChannelFunction>
+            SEMANTIC_RELAY_FUNCTIONS =
+                    Map.ofEntries(
+                            Map.entry(
+                                    GatewayLockValue.class,
+                                    SUPLA_CHANNELFNC_CONTROLLINGTHEGATEWAYLOCK),
+                            Map.entry(GateValue.class, SUPLA_CHANNELFNC_CONTROLLINGTHEGATE),
+                            Map.entry(
+                                    GarageDoorValue.class,
+                                    SUPLA_CHANNELFNC_CONTROLLINGTHEGARAGEDOOR),
+                            Map.entry(DoorLockValue.class, SUPLA_CHANNELFNC_CONTROLLINGTHEDOORLOCK),
+                            Map.entry(
+                                    RollerShutterValue.class,
+                                    SUPLA_CHANNELFNC_CONTROLLINGTHEROLLERSHUTTER),
+                            Map.entry(PowerSwitchValue.class, SUPLA_CHANNELFNC_POWERSWITCH),
+                            Map.entry(LightSwitchValue.class, SUPLA_CHANNELFNC_LIGHTSWITCH),
+                            Map.entry(StaircaseTimerValue.class, SUPLA_CHANNELFNC_STAIRCASETIMER),
+                            Map.entry(
+                                    RoofWindowValue.class,
+                                    SUPLA_CHANNELFNC_CONTROLLINGTHEROOFWINDOW),
+                            Map.entry(
+                                    FacadeBlindValue.class,
+                                    SUPLA_CHANNELFNC_CONTROLLINGTHEFACADEBLIND),
+                            Map.entry(TerraceAwningValue.class, SUPLA_CHANNELFNC_TERRACE_AWNING),
+                            Map.entry(
+                                    ProjectorScreenValue.class, SUPLA_CHANNELFNC_PROJECTOR_SCREEN),
+                            Map.entry(CurtainValue.class, SUPLA_CHANNELFNC_CURTAIN),
+                            Map.entry(VerticalBlindValue.class, SUPLA_CHANNELFNC_VERTICAL_BLIND),
+                            Map.entry(
+                                    RollerGarageDoorValue.class,
+                                    SUPLA_CHANNELFNC_ROLLER_GARAGE_DOOR),
+                            Map.entry(PumpSwitchValue.class, SUPLA_CHANNELFNC_PUMPSWITCH),
+                            Map.entry(
+                                    HeatOrColdSourceSwitchValue.class,
+                                    SUPLA_CHANNELFNC_HEATORCOLDSOURCESWITCH));
 
     final Random random;
     final Logger log = org.slf4j.LoggerFactory.getLogger(EncodeAndDecodeTest.class);
@@ -129,9 +129,9 @@ class EncodeAndDecodeTest {
             ChannelType type, Class<? extends ChannelValue> channelValueClass) {
         var functions =
                 Optional.ofNullable(SEMANTIC_RELAY_FUNCTIONS.get(channelValueClass))
-                        .map(Set::of)
-                        .orElseGet(Set::of);
-        return new ChannelDescription(type, Set.of(), functions);
+                        .map(List::of)
+                        .orElseGet(List::of);
+        return new ChannelDescription(type, Set.of(), functions, Optional.empty());
     }
 
     class ClassToObject implements ChannelClassSwitch.Callback<ChannelValue> {

--- a/protocol/src/main/java/pl/grzeslowski/jsupla/protocol/api/channeltype/ChannelDescription.java
+++ b/protocol/src/main/java/pl/grzeslowski/jsupla/protocol/api/channeltype/ChannelDescription.java
@@ -1,9 +1,36 @@
 package pl.grzeslowski.jsupla.protocol.api.channeltype;
 
+import static java.util.Collections.emptyList;
+import static java.util.Objects.requireNonNullElse;
+import static pl.grzeslowski.jsupla.protocol.api.ChannelFunction.SUPLA_CHANNELFNC_NONE;
+
+import java.util.List;
+import java.util.Optional;
 import java.util.Set;
-import pl.grzeslowski.jsupla.protocol.api.BitFunction;
 import pl.grzeslowski.jsupla.protocol.api.ChannelFlag;
+import pl.grzeslowski.jsupla.protocol.api.ChannelFunction;
 import pl.grzeslowski.jsupla.protocol.api.ChannelType;
 
 public record ChannelDescription(
-        ChannelType type, Set<ChannelFlag> flags, Set<BitFunction> functions) {}
+        ChannelType type,
+        Set<ChannelFlag> flags,
+        List<ChannelFunction> functions,
+        Optional<ChannelFunction> selectedFunction) {
+    public ChannelDescription {
+        flags = requireNonNullElse(flags, Set.of());
+        functions = List.copyOf(requireNonNullElse(functions, emptyList()));
+        selectedFunction = requireNonNullElse(selectedFunction, Optional.empty());
+    }
+
+    public static ChannelDescription fromValues(
+            ChannelType type, Set<ChannelFlag> flags, Integer funcList, int defaultValue) {
+        return new ChannelDescription(
+                type,
+                flags,
+                funcList == null
+                        ? List.of()
+                        : ChannelFunction.findByMask(funcList).stream().toList(),
+                ChannelFunction.findByValue(defaultValue)
+                        .filter(function -> function != SUPLA_CHANNELFNC_NONE));
+    }
+}

--- a/protocol/src/main/java/pl/grzeslowski/jsupla/protocol/api/channeltype/decoders/ChannelTypeDecoder.java
+++ b/protocol/src/main/java/pl/grzeslowski/jsupla/protocol/api/channeltype/decoders/ChannelTypeDecoder.java
@@ -4,12 +4,14 @@ import static java.lang.String.format;
 import static lombok.AccessLevel.PRIVATE;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
+import pl.grzeslowski.jsupla.protocol.api.ChannelFunction;
 import pl.grzeslowski.jsupla.protocol.api.ChannelType;
 import pl.grzeslowski.jsupla.protocol.api.channeltype.ChannelDescription;
 import pl.grzeslowski.jsupla.protocol.api.channeltype.value.*;
@@ -45,19 +47,19 @@ public final class ChannelTypeDecoder {
     }
 
     public ChannelValue decode(final ChannelDescription description, final byte[] value) {
-        if (description == null || description.type() == null) {
-            return new UnknownValue(value, "Channel description or channel type is null");
+        if (description == null) {
+            return new UnknownValue(value, "Channel description is null");
         }
-        return findChannelTypeDecoder(description.type())
+        return findDecoder(description)
                 .map(decoder -> decoder.decode(value, description))
                 .map(ChannelValue.class::cast)
                 .orElseGet(
                         () -> {
                             val message =
                                     format(
-                                            "Don't know how to map channel type %s to channel"
-                                                    + " value!",
-                                            description.type());
+                                            "Don't know how to map channel description %s to"
+                                                    + " channel value!",
+                                            description);
                             if (log.isWarnEnabled()) {
                                 log.warn(message + " value={}", Arrays.toString(value));
                             }
@@ -66,21 +68,54 @@ public final class ChannelTypeDecoder {
     }
 
     public Class<? extends ChannelValue> findClass(final ChannelDescription description) {
-        if (description == null || description.type() == null) {
+        if (description == null) {
             return UnknownValue.class;
         }
         var maybe =
-                findChannelTypeDecoder(description.type())
-                        .map(decoder -> decoder.getChannelValueType(description));
+                findDecoder(description).map(decoder -> decoder.getChannelValueType(description));
         if (maybe.isEmpty()) {
-            log.warn("Don't know how to map channel type {} to channel value!", description.type());
+            log.warn("Don't know how to map channel description {} to channel value!", description);
             return UnknownValue.class;
         }
         return maybe.get();
     }
 
+    private Optional<ChannelValueDecoder<?>> findDecoder(ChannelDescription description) {
+        return description
+                .selectedFunction()
+                .flatMap(this::findChannelFunctionDecoder)
+                .or(() -> findSingleChannelFunctionDecoder(description.functions()))
+                .or(() -> findChannelTypeDecoder(description.type()));
+    }
+
+    private Optional<ChannelValueDecoder<?>> findSingleChannelFunctionDecoder(
+            List<ChannelFunction> functions) {
+        var functionDecoders =
+                functions.stream()
+                        .flatMap(function -> streamOfFunctionDecoders(function))
+                        .distinct()
+                        .toList();
+        return functionDecoders.size() == 1
+                ? Optional.of(functionDecoders.getFirst())
+                : Optional.empty();
+    }
+
+    private Optional<ChannelValueDecoder<?>> findChannelFunctionDecoder(
+            ChannelFunction channelFunction) {
+        return streamOfFunctionDecoders(channelFunction).findAny();
+    }
+
     private Optional<ChannelValueDecoder<?>> findChannelTypeDecoder(ChannelType channelType) {
+        if (channelType == null) {
+            return Optional.empty();
+        }
         return streamOfDecoders(channelType).findAny();
+    }
+
+    /** VisibleForTesting */
+    Stream<ChannelValueDecoder<?>> streamOfFunctionDecoders(ChannelFunction channelFunction) {
+        return decoders.stream()
+                .filter(decoder -> decoder.supportedChannelFunctions().contains(channelFunction));
     }
 
     /** VisibleForTesting */

--- a/protocol/src/main/java/pl/grzeslowski/jsupla/protocol/api/channeltype/decoders/ChannelValueDecoder.java
+++ b/protocol/src/main/java/pl/grzeslowski/jsupla/protocol/api/channeltype/decoders/ChannelValueDecoder.java
@@ -11,9 +11,7 @@ public interface ChannelValueDecoder<ChannelValueT extends ChannelValue>
         extends Decoder<ChannelValueT> {
     Set<ChannelType> supportedChannelValueTypes();
 
-    default Set<ChannelFunction> supportedChannelFunctions() {
-        return Set.of();
-    }
+    Set<ChannelFunction> supportedChannelFunctions();
 
     Class<ChannelValueT> getChannelValueType();
 

--- a/protocol/src/main/java/pl/grzeslowski/jsupla/protocol/api/channeltype/decoders/ChannelValueDecoder.java
+++ b/protocol/src/main/java/pl/grzeslowski/jsupla/protocol/api/channeltype/decoders/ChannelValueDecoder.java
@@ -1,6 +1,7 @@
 package pl.grzeslowski.jsupla.protocol.api.channeltype.decoders;
 
 import java.util.Set;
+import pl.grzeslowski.jsupla.protocol.api.ChannelFunction;
 import pl.grzeslowski.jsupla.protocol.api.ChannelType;
 import pl.grzeslowski.jsupla.protocol.api.channeltype.ChannelDescription;
 import pl.grzeslowski.jsupla.protocol.api.channeltype.value.ChannelValue;
@@ -9,6 +10,10 @@ import pl.grzeslowski.jsupla.protocol.api.decoders.Decoder;
 public interface ChannelValueDecoder<ChannelValueT extends ChannelValue>
         extends Decoder<ChannelValueT> {
     Set<ChannelType> supportedChannelValueTypes();
+
+    default Set<ChannelFunction> supportedChannelFunctions() {
+        return Set.of();
+    }
 
     Class<ChannelValueT> getChannelValueType();
 

--- a/protocol/src/main/java/pl/grzeslowski/jsupla/protocol/api/channeltype/decoders/ElectricityMeterDecoder.java
+++ b/protocol/src/main/java/pl/grzeslowski/jsupla/protocol/api/channeltype/decoders/ElectricityMeterDecoder.java
@@ -15,6 +15,7 @@ import java.util.stream.IntStream;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import pl.grzeslowski.jsupla.protocol.api.BigDecimalDivider;
+import pl.grzeslowski.jsupla.protocol.api.ChannelFunction;
 import pl.grzeslowski.jsupla.protocol.api.ChannelType;
 import pl.grzeslowski.jsupla.protocol.api.channeltype.value.ElectricityMeterValue;
 import pl.grzeslowski.jsupla.protocol.api.decoders.ElectricityMeterExtendedValueDecoder;
@@ -47,6 +48,11 @@ class ElectricityMeterDecoder implements ChannelValueDecoder<ElectricityMeterVal
     @Override
     public Set<ChannelType> supportedChannelValueTypes() {
         return Set.of(EV_TYPE_ELECTRICITY_METER_MEASUREMENT_V1);
+    }
+
+    @Override
+    public Set<ChannelFunction> supportedChannelFunctions() {
+        return Set.of();
     }
 
     @Override

--- a/protocol/src/main/java/pl/grzeslowski/jsupla/protocol/api/channeltype/decoders/ElectricityMeterSimpleDecoder.java
+++ b/protocol/src/main/java/pl/grzeslowski/jsupla/protocol/api/channeltype/decoders/ElectricityMeterSimpleDecoder.java
@@ -5,6 +5,7 @@ import static pl.grzeslowski.jsupla.protocol.api.ElectricMeterPhaseFlag.*;
 
 import java.util.Set;
 import pl.grzeslowski.jsupla.protocol.api.BigDecimalDivider;
+import pl.grzeslowski.jsupla.protocol.api.ChannelFunction;
 import pl.grzeslowski.jsupla.protocol.api.ChannelType;
 import pl.grzeslowski.jsupla.protocol.api.channeltype.value.ElectricityMeterSimpleValue;
 import pl.grzeslowski.jsupla.protocol.api.decoders.ElectricityMeterValueDecoder;
@@ -18,6 +19,11 @@ public class ElectricityMeterSimpleDecoder
     @Override
     public Set<ChannelType> supportedChannelValueTypes() {
         return Set.of(SUPLA_CHANNELTYPE_ELECTRICITY_METER);
+    }
+
+    @Override
+    public Set<ChannelFunction> supportedChannelFunctions() {
+        return Set.of(ChannelFunction.SUPLA_CHANNELFNC_ELECTRICITY_METER);
     }
 
     @Override

--- a/protocol/src/main/java/pl/grzeslowski/jsupla/protocol/api/channeltype/decoders/ElectricityMeterV2Decoder.java
+++ b/protocol/src/main/java/pl/grzeslowski/jsupla/protocol/api/channeltype/decoders/ElectricityMeterV2Decoder.java
@@ -15,6 +15,7 @@ import java.util.stream.IntStream;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import pl.grzeslowski.jsupla.protocol.api.BigDecimalDivider;
+import pl.grzeslowski.jsupla.protocol.api.ChannelFunction;
 import pl.grzeslowski.jsupla.protocol.api.ChannelType;
 import pl.grzeslowski.jsupla.protocol.api.channeltype.value.ElectricityMeterValue;
 import pl.grzeslowski.jsupla.protocol.api.decoders.ElectricityMeterExtendedValueV2Decoder;
@@ -47,6 +48,11 @@ class ElectricityMeterV2Decoder implements ChannelValueDecoder<ElectricityMeterV
     @Override
     public Set<ChannelType> supportedChannelValueTypes() {
         return Set.of(EV_TYPE_ELECTRICITY_METER_MEASUREMENT_V2);
+    }
+
+    @Override
+    public Set<ChannelFunction> supportedChannelFunctions() {
+        return Set.of();
     }
 
     @Override

--- a/protocol/src/main/java/pl/grzeslowski/jsupla/protocol/api/channeltype/decoders/ElectricityMeterV3Decoder.java
+++ b/protocol/src/main/java/pl/grzeslowski/jsupla/protocol/api/channeltype/decoders/ElectricityMeterV3Decoder.java
@@ -15,6 +15,7 @@ import java.util.stream.IntStream;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import pl.grzeslowski.jsupla.protocol.api.BigDecimalDivider;
+import pl.grzeslowski.jsupla.protocol.api.ChannelFunction;
 import pl.grzeslowski.jsupla.protocol.api.ChannelType;
 import pl.grzeslowski.jsupla.protocol.api.channeltype.value.ElectricityMeterValue;
 import pl.grzeslowski.jsupla.protocol.api.channeltype.value.ElectricityMeterValue.PhaseSequence;
@@ -50,6 +51,11 @@ class ElectricityMeterV3Decoder implements ChannelValueDecoder<ElectricityMeterV
     @Override
     public Set<ChannelType> supportedChannelValueTypes() {
         return Set.of(EV_TYPE_ELECTRICITY_METER_MEASUREMENT_V3);
+    }
+
+    @Override
+    public Set<ChannelFunction> supportedChannelFunctions() {
+        return Set.of();
     }
 
     @Override

--- a/protocol/src/main/java/pl/grzeslowski/jsupla/protocol/api/channeltype/decoders/HeatpolThermostatTypeDecoder.java
+++ b/protocol/src/main/java/pl/grzeslowski/jsupla/protocol/api/channeltype/decoders/HeatpolThermostatTypeDecoder.java
@@ -5,6 +5,7 @@ import static pl.grzeslowski.jsupla.protocol.api.ChannelType.SUPLA_CHANNELTYPE_T
 
 import java.math.BigDecimal;
 import java.util.Set;
+import pl.grzeslowski.jsupla.protocol.api.ChannelFunction;
 import pl.grzeslowski.jsupla.protocol.api.ChannelType;
 import pl.grzeslowski.jsupla.protocol.api.ThermostatValueFlag;
 import pl.grzeslowski.jsupla.protocol.api.channeltype.value.HeatpolThermostatValue;
@@ -16,6 +17,11 @@ public class HeatpolThermostatTypeDecoder implements ChannelValueDecoder<Heatpol
     @Override
     public Set<ChannelType> supportedChannelValueTypes() {
         return Set.of(SUPLA_CHANNELTYPE_THERMOSTAT_HEATPOL_HOMEPLUS);
+    }
+
+    @Override
+    public Set<ChannelFunction> supportedChannelFunctions() {
+        return Set.of(ChannelFunction.SUPLA_CHANNELFNC_THERMOSTAT_HEATPOL_HOMEPLUS);
     }
 
     @Override

--- a/protocol/src/main/java/pl/grzeslowski/jsupla/protocol/api/channeltype/decoders/HumidityTypeDecoder.java
+++ b/protocol/src/main/java/pl/grzeslowski/jsupla/protocol/api/channeltype/decoders/HumidityTypeDecoder.java
@@ -9,6 +9,7 @@ import java.math.BigDecimal;
 import java.math.MathContext;
 import java.util.Set;
 import lombok.val;
+import pl.grzeslowski.jsupla.protocol.api.ChannelFunction;
 import pl.grzeslowski.jsupla.protocol.api.ChannelType;
 import pl.grzeslowski.jsupla.protocol.api.Preconditions;
 import pl.grzeslowski.jsupla.protocol.api.channeltype.value.HumidityValue;
@@ -22,6 +23,11 @@ class HumidityTypeDecoder implements ChannelValueDecoder<HumidityValue> {
     @Override
     public Set<ChannelType> supportedChannelValueTypes() {
         return Set.of(SUPLA_CHANNELTYPE_HUMIDITYSENSOR);
+    }
+
+    @Override
+    public Set<ChannelFunction> supportedChannelFunctions() {
+        return Set.of(ChannelFunction.SUPLA_CHANNELFNC_HUMIDITY);
     }
 
     @Override

--- a/protocol/src/main/java/pl/grzeslowski/jsupla/protocol/api/channeltype/decoders/HvacTypeDecoder.java
+++ b/protocol/src/main/java/pl/grzeslowski/jsupla/protocol/api/channeltype/decoders/HvacTypeDecoder.java
@@ -10,6 +10,7 @@ import java.math.BigDecimal;
 import java.util.Set;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import pl.grzeslowski.jsupla.protocol.api.ChannelFunction;
 import pl.grzeslowski.jsupla.protocol.api.ChannelType;
 import pl.grzeslowski.jsupla.protocol.api.HvacFlag;
 import pl.grzeslowski.jsupla.protocol.api.HvacMode;
@@ -26,6 +27,18 @@ public class HvacTypeDecoder implements ChannelValueDecoder<HvacValue> {
     @Override
     public Set<ChannelType> supportedChannelValueTypes() {
         return Set.of(SUPLA_CHANNELTYPE_HVAC);
+    }
+
+    @Override
+    public Set<ChannelFunction> supportedChannelFunctions() {
+        return Set.of(
+                ChannelFunction.SUPLA_CHANNELFNC_HVAC_THERMOSTAT,
+                ChannelFunction.SUPLA_CHANNELFNC_HVAC_THERMOSTAT_HEAT_COOL,
+                ChannelFunction.SUPLA_CHANNELFNC_HVAC_DRYER,
+                ChannelFunction.SUPLA_CHANNELFNC_HVAC_FAN,
+                ChannelFunction.SUPLA_CHANNELFNC_HVAC_THERMOSTAT_DIFFERENTIAL,
+                ChannelFunction.SUPLA_CHANNELFNC_HVAC_DOMESTIC_HOT_WATER,
+                ChannelFunction.SUPLA_CHANNELFNC_HVAC_HRV);
     }
 
     @Override

--- a/protocol/src/main/java/pl/grzeslowski/jsupla/protocol/api/channeltype/decoders/PercentageTypeDecoder.java
+++ b/protocol/src/main/java/pl/grzeslowski/jsupla/protocol/api/channeltype/decoders/PercentageTypeDecoder.java
@@ -3,6 +3,7 @@ package pl.grzeslowski.jsupla.protocol.api.channeltype.decoders;
 import static pl.grzeslowski.jsupla.protocol.api.ChannelType.SUPLA_CHANNELTYPE_DIMMER;
 
 import java.util.Set;
+import pl.grzeslowski.jsupla.protocol.api.ChannelFunction;
 import pl.grzeslowski.jsupla.protocol.api.ChannelType;
 import pl.grzeslowski.jsupla.protocol.api.channeltype.value.PercentValue;
 import pl.grzeslowski.jsupla.protocol.api.decoders.PrimitiveDecoder;
@@ -11,6 +12,11 @@ class PercentageTypeDecoder implements ChannelValueDecoder<PercentValue> {
     @Override
     public Set<ChannelType> supportedChannelValueTypes() {
         return Set.of(SUPLA_CHANNELTYPE_DIMMER);
+    }
+
+    @Override
+    public Set<ChannelFunction> supportedChannelFunctions() {
+        return Set.of(ChannelFunction.SUPLA_CHANNELFNC_DIMMER);
     }
 
     @Override

--- a/protocol/src/main/java/pl/grzeslowski/jsupla/protocol/api/channeltype/decoders/PressureTypeDecoder.java
+++ b/protocol/src/main/java/pl/grzeslowski/jsupla/protocol/api/channeltype/decoders/PressureTypeDecoder.java
@@ -6,6 +6,7 @@ import static pl.grzeslowski.jsupla.protocol.api.decoders.PrimitiveDecoder.INSTA
 import java.math.BigDecimal;
 import java.util.Set;
 import lombok.val;
+import pl.grzeslowski.jsupla.protocol.api.ChannelFunction;
 import pl.grzeslowski.jsupla.protocol.api.ChannelType;
 import pl.grzeslowski.jsupla.protocol.api.channeltype.value.PressureValue;
 
@@ -20,6 +21,11 @@ class PressureTypeDecoder implements ChannelValueDecoder<PressureValue> {
     @Override
     public Set<ChannelType> supportedChannelValueTypes() {
         return Set.of(SUPLA_CHANNELTYPE_PRESSURESENSOR);
+    }
+
+    @Override
+    public Set<ChannelFunction> supportedChannelFunctions() {
+        return Set.of(ChannelFunction.SUPLA_CHANNELFNC_PRESSURESENSOR);
     }
 
     @Override

--- a/protocol/src/main/java/pl/grzeslowski/jsupla/protocol/api/channeltype/decoders/RainTypeDecoder.java
+++ b/protocol/src/main/java/pl/grzeslowski/jsupla/protocol/api/channeltype/decoders/RainTypeDecoder.java
@@ -6,6 +6,7 @@ import static pl.grzeslowski.jsupla.protocol.api.decoders.PrimitiveDecoder.INSTA
 import java.math.BigDecimal;
 import java.util.Set;
 import lombok.val;
+import pl.grzeslowski.jsupla.protocol.api.ChannelFunction;
 import pl.grzeslowski.jsupla.protocol.api.ChannelType;
 import pl.grzeslowski.jsupla.protocol.api.channeltype.value.RainValue;
 
@@ -20,6 +21,11 @@ class RainTypeDecoder implements ChannelValueDecoder<RainValue> {
     @Override
     public Set<ChannelType> supportedChannelValueTypes() {
         return Set.of(SUPLA_CHANNELTYPE_RAINSENSOR);
+    }
+
+    @Override
+    public Set<ChannelFunction> supportedChannelFunctions() {
+        return Set.of(ChannelFunction.SUPLA_CHANNELFNC_RAINSENSOR);
     }
 
     @Override

--- a/protocol/src/main/java/pl/grzeslowski/jsupla/protocol/api/channeltype/decoders/RelayTypeDecoder.java
+++ b/protocol/src/main/java/pl/grzeslowski/jsupla/protocol/api/channeltype/decoders/RelayTypeDecoder.java
@@ -1,12 +1,13 @@
 package pl.grzeslowski.jsupla.protocol.api.channeltype.decoders;
 
 import static java.lang.String.format;
+import static pl.grzeslowski.jsupla.protocol.api.ChannelFunction.*;
 import static pl.grzeslowski.jsupla.protocol.api.ChannelType.*;
 import static pl.grzeslowski.jsupla.protocol.api.decoders.PrimitiveDecoder.INSTANCE;
 
 import java.util.List;
 import java.util.Set;
-import pl.grzeslowski.jsupla.protocol.api.BitFunction;
+import pl.grzeslowski.jsupla.protocol.api.ChannelFunction;
 import pl.grzeslowski.jsupla.protocol.api.ChannelType;
 import pl.grzeslowski.jsupla.protocol.api.Preconditions;
 import pl.grzeslowski.jsupla.protocol.api.channeltype.ChannelDescription;
@@ -16,87 +17,87 @@ class RelayTypeDecoder implements ChannelValueDecoder<OnOffValue> {
     private static final List<SemanticRelayValue> SEMANTIC_RELAY_VALUES =
             List.of(
                     new SemanticRelayValue(
-                            BitFunction.SUPLA_BIT_FUNC_CONTROLLINGTHEGATEWAYLOCK,
+                            SUPLA_CHANNELFNC_CONTROLLINGTHEGATEWAYLOCK,
                             GatewayLockValue.class,
                             GatewayLockValue.UNLOCKED,
                             GatewayLockValue.LOCKED),
                     new SemanticRelayValue(
-                            BitFunction.SUPLA_BIT_FUNC_CONTROLLINGTHEGATE,
+                            SUPLA_CHANNELFNC_CONTROLLINGTHEGATE,
                             GateValue.class,
                             GateValue.OPEN,
                             GateValue.CLOSE),
                     new SemanticRelayValue(
-                            BitFunction.SUPLA_BIT_FUNC_CONTROLLINGTHEGARAGEDOOR,
+                            SUPLA_CHANNELFNC_CONTROLLINGTHEGARAGEDOOR,
                             GarageDoorValue.class,
                             GarageDoorValue.OPEN,
                             GarageDoorValue.CLOSE),
                     new SemanticRelayValue(
-                            BitFunction.SUPLA_BIT_FUNC_CONTROLLINGTHEDOORLOCK,
+                            SUPLA_CHANNELFNC_CONTROLLINGTHEDOORLOCK,
                             DoorLockValue.class,
                             DoorLockValue.UNLOCKED,
                             DoorLockValue.LOCKED),
                     new SemanticRelayValue(
-                            BitFunction.SUPLA_BIT_FUNC_CONTROLLINGTHEROLLERSHUTTER,
+                            SUPLA_CHANNELFNC_CONTROLLINGTHEROLLERSHUTTER,
                             RollerShutterValue.class,
                             RollerShutterValue.OPEN,
                             RollerShutterValue.CLOSE),
                     new SemanticRelayValue(
-                            BitFunction.SUPLA_BIT_FUNC_POWERSWITCH,
+                            SUPLA_CHANNELFNC_POWERSWITCH,
                             PowerSwitchValue.class,
                             PowerSwitchValue.ON,
                             PowerSwitchValue.OFF),
                     new SemanticRelayValue(
-                            BitFunction.SUPLA_BIT_FUNC_LIGHTSWITCH,
+                            SUPLA_CHANNELFNC_LIGHTSWITCH,
                             LightSwitchValue.class,
                             LightSwitchValue.ON,
                             LightSwitchValue.OFF),
                     new SemanticRelayValue(
-                            BitFunction.SUPLA_BIT_FUNC_STAIRCASETIMER,
+                            SUPLA_CHANNELFNC_STAIRCASETIMER,
                             StaircaseTimerValue.class,
                             StaircaseTimerValue.ON,
                             StaircaseTimerValue.OFF),
                     new SemanticRelayValue(
-                            BitFunction.SUPLA_BIT_FUNC_CONTROLLINGTHEROOFWINDOW,
+                            SUPLA_CHANNELFNC_CONTROLLINGTHEROOFWINDOW,
                             RoofWindowValue.class,
                             RoofWindowValue.OPEN,
                             RoofWindowValue.CLOSE),
                     new SemanticRelayValue(
-                            BitFunction.SUPLA_BIT_FUNC_CONTROLLINGTHEFACADEBLIND,
+                            SUPLA_CHANNELFNC_CONTROLLINGTHEFACADEBLIND,
                             FacadeBlindValue.class,
                             FacadeBlindValue.OPEN,
                             FacadeBlindValue.CLOSE),
                     new SemanticRelayValue(
-                            BitFunction.SUPLA_BIT_FUNC_TERRACE_AWNING,
+                            SUPLA_CHANNELFNC_TERRACE_AWNING,
                             TerraceAwningValue.class,
                             TerraceAwningValue.OPEN,
                             TerraceAwningValue.CLOSE),
                     new SemanticRelayValue(
-                            BitFunction.SUPLA_BIT_FUNC_PROJECTOR_SCREEN,
+                            SUPLA_CHANNELFNC_PROJECTOR_SCREEN,
                             ProjectorScreenValue.class,
                             ProjectorScreenValue.OPEN,
                             ProjectorScreenValue.CLOSE),
                     new SemanticRelayValue(
-                            BitFunction.SUPLA_BIT_FUNC_CURTAIN,
+                            SUPLA_CHANNELFNC_CURTAIN,
                             CurtainValue.class,
                             CurtainValue.OPEN,
                             CurtainValue.CLOSE),
                     new SemanticRelayValue(
-                            BitFunction.SUPLA_BIT_FUNC_VERTICAL_BLIND,
+                            SUPLA_CHANNELFNC_VERTICAL_BLIND,
                             VerticalBlindValue.class,
                             VerticalBlindValue.OPEN,
                             VerticalBlindValue.CLOSE),
                     new SemanticRelayValue(
-                            BitFunction.SUPLA_BIT_FUNC_ROLLER_GARAGE_DOOR,
+                            SUPLA_CHANNELFNC_ROLLER_GARAGE_DOOR,
                             RollerGarageDoorValue.class,
                             RollerGarageDoorValue.OPEN,
                             RollerGarageDoorValue.CLOSE),
                     new SemanticRelayValue(
-                            BitFunction.SUPLA_BIT_FUNC_PUMPSWITCH,
+                            SUPLA_CHANNELFNC_PUMPSWITCH,
                             PumpSwitchValue.class,
                             PumpSwitchValue.ON,
                             PumpSwitchValue.OFF),
                     new SemanticRelayValue(
-                            BitFunction.SUPLA_BIT_FUNC_HEATORCOLDSOURCESWITCH,
+                            SUPLA_CHANNELFNC_HEATORCOLDSOURCESWITCH,
                             HeatOrColdSourceSwitchValue.class,
                             HeatOrColdSourceSwitchValue.ON,
                             HeatOrColdSourceSwitchValue.OFF));
@@ -112,6 +113,11 @@ class RelayTypeDecoder implements ChannelValueDecoder<OnOffValue> {
                 SUPLA_CHANNELTYPE_2XRELAYG5LA1A,
                 SUPLA_CHANNELTYPE_RELAY,
                 SUPLA_CHANNELTYPE_BINARYSENSOR);
+    }
+
+    @Override
+    public Set<ChannelFunction> supportedChannelFunctions() {
+        return Set.copyOf(supportedSemanticFunctions());
     }
 
     @Override
@@ -160,13 +166,24 @@ class RelayTypeDecoder implements ChannelValueDecoder<OnOffValue> {
         return semanticRelayValue != null ? semanticRelayValue.type() : OnOffValue.class;
     }
 
-    static List<BitFunction> supportedSemanticFunctions() {
+    static List<ChannelFunction> supportedSemanticFunctions() {
         return SEMANTIC_RELAY_VALUES.stream().map(SemanticRelayValue::function).toList();
     }
 
     private SemanticRelayValue semanticRelayValue(final ChannelDescription description) {
         if (description == null || description.functions() == null) {
             return null;
+        }
+        var selectedValue =
+                description
+                        .selectedFunction()
+                        .flatMap(
+                                selected ->
+                                        SEMANTIC_RELAY_VALUES.stream()
+                                                .filter(value -> value.function() == selected)
+                                                .findAny());
+        if (selectedValue.isPresent()) {
+            return selectedValue.get();
         }
         var values =
                 SEMANTIC_RELAY_VALUES.stream()
@@ -179,7 +196,7 @@ class RelayTypeDecoder implements ChannelValueDecoder<OnOffValue> {
     }
 
     private record SemanticRelayValue(
-            BitFunction function,
+            ChannelFunction function,
             Class<? extends ChannelValue> type,
             ChannelValue active,
             ChannelValue inactive) {}

--- a/protocol/src/main/java/pl/grzeslowski/jsupla/protocol/api/channeltype/decoders/RgbTypeDecoder.java
+++ b/protocol/src/main/java/pl/grzeslowski/jsupla/protocol/api/channeltype/decoders/RgbTypeDecoder.java
@@ -5,6 +5,7 @@ import static pl.grzeslowski.jsupla.protocol.api.ProtocolHelpers.toUnsignedByte;
 
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
+import pl.grzeslowski.jsupla.protocol.api.ChannelFunction;
 import pl.grzeslowski.jsupla.protocol.api.ChannelType;
 import pl.grzeslowski.jsupla.protocol.api.channeltype.value.RgbValue;
 import pl.grzeslowski.jsupla.protocol.api.channeltype.value.RgbValue.Command;
@@ -19,6 +20,15 @@ class RgbTypeDecoder implements ChannelValueDecoder<RgbValue> {
                 SUPLA_CHANNELTYPE_RGBLEDCONTROLLER,
                 SUPLA_CHANNELTYPE_DIMMERANDRGBLED,
                 SUPLA_CHANNELTYPE_DISTANCESENSOR);
+    }
+
+    @Override
+    public Set<ChannelFunction> supportedChannelFunctions() {
+        return Set.of(
+                ChannelFunction.SUPLA_CHANNELFNC_RGBLIGHTING,
+                ChannelFunction.SUPLA_CHANNELFNC_DIMMERANDRGBLIGHTING,
+                ChannelFunction.SUPLA_CHANNELFNC_DIMMER_CCT,
+                ChannelFunction.SUPLA_CHANNELFNC_DIMMER_CCT_AND_RGB);
     }
 
     @Override

--- a/protocol/src/main/java/pl/grzeslowski/jsupla/protocol/api/channeltype/decoders/ThermometerDoubleTypeDecoder.java
+++ b/protocol/src/main/java/pl/grzeslowski/jsupla/protocol/api/channeltype/decoders/ThermometerDoubleTypeDecoder.java
@@ -6,6 +6,7 @@ import static pl.grzeslowski.jsupla.protocol.api.decoders.PrimitiveDecoder.INSTA
 
 import java.util.Set;
 import lombok.val;
+import pl.grzeslowski.jsupla.protocol.api.ChannelFunction;
 import pl.grzeslowski.jsupla.protocol.api.ChannelType;
 import pl.grzeslowski.jsupla.protocol.api.channeltype.value.TemperatureDoubleValue;
 
@@ -21,6 +22,11 @@ class ThermometerDoubleTypeDecoder implements ChannelValueDecoder<TemperatureDou
     @Override
     public Set<ChannelType> supportedChannelValueTypes() {
         return Set.of(SUPLA_CHANNELTYPE_THERMOMETER, SUPLA_CHANNELTYPE_THERMOMETERDS18B20);
+    }
+
+    @Override
+    public Set<ChannelFunction> supportedChannelFunctions() {
+        return Set.of(ChannelFunction.SUPLA_CHANNELFNC_THERMOMETER);
     }
 
     @Override

--- a/protocol/src/main/java/pl/grzeslowski/jsupla/protocol/api/channeltype/decoders/ThermometerTypeDecoder.java
+++ b/protocol/src/main/java/pl/grzeslowski/jsupla/protocol/api/channeltype/decoders/ThermometerTypeDecoder.java
@@ -9,6 +9,7 @@ import java.math.BigDecimal;
 import java.math.MathContext;
 import java.util.Set;
 import lombok.val;
+import pl.grzeslowski.jsupla.protocol.api.ChannelFunction;
 import pl.grzeslowski.jsupla.protocol.api.ChannelType;
 import pl.grzeslowski.jsupla.protocol.api.Preconditions;
 import pl.grzeslowski.jsupla.protocol.api.channeltype.value.TemperatureAndHumidityValue;
@@ -45,6 +46,11 @@ class ThermometerTypeDecoder implements ChannelValueDecoder<TemperatureAndHumidi
                 SUPLA_CHANNELTYPE_AM2302,
                 SUPLA_CHANNELTYPE_AM2301,
                 SUPLA_CHANNELTYPE_HUMIDITYANDTEMPSENSOR);
+    }
+
+    @Override
+    public Set<ChannelFunction> supportedChannelFunctions() {
+        return Set.of(ChannelFunction.SUPLA_CHANNELFNC_HUMIDITYANDTEMPERATURE);
     }
 
     @Override

--- a/protocol/src/main/java/pl/grzeslowski/jsupla/protocol/api/channeltype/decoders/TimerMsecDecoder.java
+++ b/protocol/src/main/java/pl/grzeslowski/jsupla/protocol/api/channeltype/decoders/TimerMsecDecoder.java
@@ -4,6 +4,7 @@ import static pl.grzeslowski.jsupla.protocol.api.ChannelType.EV_TYPE_TIMER_STATE
 
 import java.time.Duration;
 import java.util.Set;
+import pl.grzeslowski.jsupla.protocol.api.ChannelFunction;
 import pl.grzeslowski.jsupla.protocol.api.ChannelType;
 import pl.grzeslowski.jsupla.protocol.api.structs.TimerStateExtendedValue;
 
@@ -17,5 +18,10 @@ class TimerMsecDecoder extends TimerAbstractDecoder {
     @Override
     public Set<ChannelType> supportedChannelValueTypes() {
         return Set.of(EV_TYPE_TIMER_STATE_V1);
+    }
+
+    @Override
+    public Set<ChannelFunction> supportedChannelFunctions() {
+        return Set.of();
     }
 }

--- a/protocol/src/main/java/pl/grzeslowski/jsupla/protocol/api/channeltype/decoders/TimerSecDecoder.java
+++ b/protocol/src/main/java/pl/grzeslowski/jsupla/protocol/api/channeltype/decoders/TimerSecDecoder.java
@@ -4,6 +4,7 @@ import static pl.grzeslowski.jsupla.protocol.api.ChannelType.EV_TYPE_TIMER_STATE
 
 import java.time.Duration;
 import java.util.Set;
+import pl.grzeslowski.jsupla.protocol.api.ChannelFunction;
 import pl.grzeslowski.jsupla.protocol.api.ChannelType;
 import pl.grzeslowski.jsupla.protocol.api.structs.TimerStateExtendedValue;
 
@@ -19,5 +20,10 @@ class TimerSecDecoder extends TimerAbstractDecoder {
     @Override
     public Set<ChannelType> supportedChannelValueTypes() {
         return Set.of(EV_TYPE_TIMER_STATE_V1_SEC);
+    }
+
+    @Override
+    public Set<ChannelFunction> supportedChannelFunctions() {
+        return Set.of();
     }
 }

--- a/protocol/src/main/java/pl/grzeslowski/jsupla/protocol/api/channeltype/decoders/WeightTypeDecoder.java
+++ b/protocol/src/main/java/pl/grzeslowski/jsupla/protocol/api/channeltype/decoders/WeightTypeDecoder.java
@@ -6,6 +6,7 @@ import static pl.grzeslowski.jsupla.protocol.api.decoders.PrimitiveDecoder.INSTA
 import java.math.BigDecimal;
 import java.util.Set;
 import lombok.val;
+import pl.grzeslowski.jsupla.protocol.api.ChannelFunction;
 import pl.grzeslowski.jsupla.protocol.api.ChannelType;
 import pl.grzeslowski.jsupla.protocol.api.channeltype.value.WeightValue;
 
@@ -20,6 +21,11 @@ class WeightTypeDecoder implements ChannelValueDecoder<WeightValue> {
     @Override
     public Set<ChannelType> supportedChannelValueTypes() {
         return Set.of(SUPLA_CHANNELTYPE_WEIGHTSENSOR);
+    }
+
+    @Override
+    public Set<ChannelFunction> supportedChannelFunctions() {
+        return Set.of(ChannelFunction.SUPLA_CHANNELFNC_WEIGHTSENSOR);
     }
 
     @Override

--- a/protocol/src/main/java/pl/grzeslowski/jsupla/protocol/api/channeltype/decoders/WindTypeDecoder.java
+++ b/protocol/src/main/java/pl/grzeslowski/jsupla/protocol/api/channeltype/decoders/WindTypeDecoder.java
@@ -6,6 +6,7 @@ import static pl.grzeslowski.jsupla.protocol.api.decoders.PrimitiveDecoder.INSTA
 import java.math.BigDecimal;
 import java.util.Set;
 import lombok.val;
+import pl.grzeslowski.jsupla.protocol.api.ChannelFunction;
 import pl.grzeslowski.jsupla.protocol.api.ChannelType;
 import pl.grzeslowski.jsupla.protocol.api.channeltype.value.WindValue;
 
@@ -20,6 +21,11 @@ class WindTypeDecoder implements ChannelValueDecoder<WindValue> {
     @Override
     public Set<ChannelType> supportedChannelValueTypes() {
         return Set.of(SUPLA_CHANNELTYPE_WINDSENSOR);
+    }
+
+    @Override
+    public Set<ChannelFunction> supportedChannelFunctions() {
+        return Set.of(ChannelFunction.SUPLA_CHANNELFNC_WINDSENSOR);
     }
 
     @Override

--- a/protocol/src/test/java/pl/grzeslowski/jsupla/protocol/api/channeltype/ChannelDescriptionTest.java
+++ b/protocol/src/test/java/pl/grzeslowski/jsupla/protocol/api/channeltype/ChannelDescriptionTest.java
@@ -1,0 +1,85 @@
+package pl.grzeslowski.jsupla.protocol.api.channeltype;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static pl.grzeslowski.jsupla.protocol.api.ChannelFunction.SUPLA_CHANNELFNC_CONTROLLINGTHEGATE;
+import static pl.grzeslowski.jsupla.protocol.api.ChannelFunction.SUPLA_CHANNELFNC_NONE;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import pl.grzeslowski.jsupla.protocol.api.ChannelFunction;
+import pl.grzeslowski.jsupla.protocol.api.ChannelType;
+
+class ChannelDescriptionTest {
+    @Test
+    void shouldCreateDescriptionFromRawValues() {
+        var funcList = SUPLA_CHANNELFNC_CONTROLLINGTHEGATE.getValue();
+        var description =
+                ChannelDescription.fromValues(
+                        ChannelType.SUPLA_CHANNELTYPE_RELAY,
+                        Set.of(),
+                        funcList,
+                        SUPLA_CHANNELFNC_CONTROLLINGTHEGATE.getValue());
+
+        assertThat(description.functions())
+                .containsExactlyElementsOf(ChannelFunction.findByMask(funcList));
+        assertThat(description.selectedFunction()).contains(SUPLA_CHANNELFNC_CONTROLLINGTHEGATE);
+    }
+
+    @Test
+    void shouldCreateDescriptionWithoutFunctionsForEmptyFuncList() {
+        assertThat(
+                        ChannelDescription.fromValues(
+                                        ChannelType.SUPLA_CHANNELTYPE_RELAY,
+                                        Set.of(),
+                                        null,
+                                        SUPLA_CHANNELFNC_NONE.getValue())
+                                .functions())
+                .isEmpty();
+        assertThat(
+                        ChannelDescription.fromValues(
+                                        ChannelType.SUPLA_CHANNELTYPE_RELAY,
+                                        Set.of(),
+                                        0,
+                                        SUPLA_CHANNELFNC_NONE.getValue())
+                                .functions())
+                .isEmpty();
+    }
+
+    @Test
+    void shouldTreatNoneDefaultValueAsEmptySelectedFunction() {
+        assertThat(
+                        ChannelDescription.fromValues(
+                                        ChannelType.SUPLA_CHANNELTYPE_RELAY,
+                                        Set.of(),
+                                        0,
+                                        SUPLA_CHANNELFNC_NONE.getValue())
+                                .selectedFunction())
+                .isEmpty();
+    }
+
+    @Test
+    void shouldTreatUnknownDefaultValueAsEmptySelectedFunction() {
+        assertThat(
+                        ChannelDescription.fromValues(
+                                        ChannelType.SUPLA_CHANNELTYPE_RELAY,
+                                        Set.of(),
+                                        0,
+                                        Integer.MIN_VALUE)
+                                .selectedFunction())
+                .isEmpty();
+    }
+
+    @Test
+    void shouldCopyFunctionList() {
+        var description =
+                new ChannelDescription(
+                        ChannelType.SUPLA_CHANNELTYPE_RELAY,
+                        Set.of(),
+                        List.of(SUPLA_CHANNELFNC_CONTROLLINGTHEGATE),
+                        Optional.empty());
+
+        assertThat(description.functions()).containsExactly(SUPLA_CHANNELFNC_CONTROLLINGTHEGATE);
+    }
+}

--- a/protocol/src/test/java/pl/grzeslowski/jsupla/protocol/api/channeltype/decoders/ChannelTypeDecoderTest.java
+++ b/protocol/src/test/java/pl/grzeslowski/jsupla/protocol/api/channeltype/decoders/ChannelTypeDecoderTest.java
@@ -1,13 +1,17 @@
 package pl.grzeslowski.jsupla.protocol.api.channeltype.decoders;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static pl.grzeslowski.jsupla.protocol.api.BitFunction.SUPLA_BIT_FUNC_CONTROLLINGTHEGATE;
+import static pl.grzeslowski.jsupla.protocol.api.ChannelFunction.SUPLA_CHANNELFNC_CONTROLLINGTHEGATE;
+import static pl.grzeslowski.jsupla.protocol.api.ChannelFunction.SUPLA_CHANNELFNC_LIGHTSWITCH;
+import static pl.grzeslowski.jsupla.protocol.api.ChannelFunction.SUPLA_CHANNELFNC_NOTIFICATION;
 import static pl.grzeslowski.jsupla.protocol.api.ChannelType.SUPLA_CHANNELTYPE_ELECTRICITY_METER;
 
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -71,7 +75,9 @@ class ChannelTypeDecoderTest {
     void shouldDecodeUnknownTypeAsUnknownValue() {
         // when
         ChannelValue value =
-                decoder.decode(new ChannelDescription(null, Set.of(), Set.of()), new byte[0]);
+                decoder.decode(
+                        new ChannelDescription(null, Set.of(), List.of(), Optional.empty()),
+                        new byte[0]);
 
         // then
         assertThat(value).isInstanceOf(UnknownValue.class);
@@ -110,14 +116,54 @@ class ChannelTypeDecoderTest {
                 new ChannelDescription(
                         ChannelType.SUPLA_CHANNELTYPE_RELAY,
                         Set.of(),
-                        Set.of(SUPLA_BIT_FUNC_CONTROLLINGTHEGATE));
+                        List.of(),
+                        Optional.of(SUPLA_CHANNELFNC_CONTROLLINGTHEGATE));
 
         assertThat(decoder.decode(description, new byte[] {1})).isEqualTo(GateValue.OPEN);
         assertThat(decoder.findClass(description)).isEqualTo(GateValue.class);
     }
 
+    @Test
+    void shouldDecodeSingleMatchingFunctionAsGateValue() {
+        var description =
+                new ChannelDescription(
+                        ChannelType.SUPLA_CHANNELTYPE_RELAY,
+                        Set.of(),
+                        List.of(SUPLA_CHANNELFNC_CONTROLLINGTHEGATE),
+                        Optional.empty());
+
+        assertThat(decoder.decode(description, new byte[] {1})).isEqualTo(GateValue.OPEN);
+        assertThat(decoder.findClass(description)).isEqualTo(GateValue.class);
+    }
+
+    @Test
+    void shouldFallbackToChannelTypeForMultipleMatchingFunctions() {
+        var description =
+                new ChannelDescription(
+                        ChannelType.SUPLA_CHANNELTYPE_RELAY,
+                        Set.of(),
+                        List.of(SUPLA_CHANNELFNC_CONTROLLINGTHEGATE, SUPLA_CHANNELFNC_LIGHTSWITCH),
+                        Optional.empty());
+
+        assertThat(decoder.decode(description, new byte[] {1})).isEqualTo(OnOffValue.ON);
+        assertThat(decoder.findClass(description)).isEqualTo(OnOffValue.class);
+    }
+
+    @Test
+    void shouldFallbackToChannelTypeForUnsupportedFunction() {
+        var description =
+                new ChannelDescription(
+                        ChannelType.SUPLA_CHANNELTYPE_RELAY,
+                        Set.of(),
+                        List.of(SUPLA_CHANNELFNC_NOTIFICATION),
+                        Optional.empty());
+
+        assertThat(decoder.decode(description, new byte[] {1})).isEqualTo(OnOffValue.ON);
+        assertThat(decoder.findClass(description)).isEqualTo(OnOffValue.class);
+    }
+
     private static ChannelDescription description(ChannelType type) {
-        return new ChannelDescription(type, Set.of(), Set.of());
+        return new ChannelDescription(type, Set.of(), List.of(), Optional.empty());
     }
 
     @ParameterizedTest(name = "{index}: should find only 0 or 1 decoder for channel type {0}")

--- a/protocol/src/test/java/pl/grzeslowski/jsupla/protocol/api/channeltype/decoders/RelayTypeDecoderTest.java
+++ b/protocol/src/test/java/pl/grzeslowski/jsupla/protocol/api/channeltype/decoders/RelayTypeDecoderTest.java
@@ -3,14 +3,16 @@ package pl.grzeslowski.jsupla.protocol.api.channeltype.decoders;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.util.EnumSet;
+import java.util.List;
+import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import pl.grzeslowski.jsupla.protocol.api.BitFunction;
+import pl.grzeslowski.jsupla.protocol.api.ChannelFunction;
 import pl.grzeslowski.jsupla.protocol.api.ChannelType;
 import pl.grzeslowski.jsupla.protocol.api.channeltype.ChannelDescription;
 import pl.grzeslowski.jsupla.protocol.api.channeltype.value.*;
@@ -38,13 +40,16 @@ class RelayTypeDecoderTest {
     @ParameterizedTest(name = "{0} should decode as {3}")
     @MethodSource("semanticRelayValues")
     void shouldDecodeSemanticRelayFunctions(
-            BitFunction function,
+            ChannelFunction function,
             ChannelValue activeValue,
             ChannelValue inactiveValue,
             Class<? extends ChannelValue> valueType) {
         var description =
                 new ChannelDescription(
-                        ChannelType.SUPLA_CHANNELTYPE_RELAY, Set.of(), Set.of(function));
+                        ChannelType.SUPLA_CHANNELTYPE_RELAY,
+                        Set.of(),
+                        List.of(function),
+                        Optional.of(function));
 
         assertThat(decoder.decode(new byte[] {1}, description)).isEqualTo(activeValue);
         assertThat(decoder.decode(new byte[] {0}, description)).isEqualTo(inactiveValue);
@@ -54,13 +59,16 @@ class RelayTypeDecoderTest {
     @ParameterizedTest(name = "{0} should reject unknown relay byte")
     @MethodSource("semanticRelayValues")
     void shouldFailForUnknownSemanticRelayValue(
-            BitFunction function,
+            ChannelFunction function,
             ChannelValue activeValue,
             ChannelValue inactiveValue,
             Class<? extends ChannelValue> valueType) {
         var description =
                 new ChannelDescription(
-                        ChannelType.SUPLA_CHANNELTYPE_RELAY, Set.of(), Set.of(function));
+                        ChannelType.SUPLA_CHANNELTYPE_RELAY,
+                        Set.of(),
+                        List.of(function),
+                        Optional.of(function));
 
         assertThatThrownBy(() -> decoder.decode(new byte[] {3}, description))
                 .isInstanceOf(IllegalArgumentException.class)
@@ -74,9 +82,10 @@ class RelayTypeDecoderTest {
                 new ChannelDescription(
                         ChannelType.SUPLA_CHANNELTYPE_RELAY,
                         Set.of(),
-                        Set.of(
-                                BitFunction.SUPLA_BIT_FUNC_LIGHTSWITCH,
-                                BitFunction.SUPLA_BIT_FUNC_CONTROLLINGTHEGATE));
+                        List.of(
+                                ChannelFunction.SUPLA_CHANNELFNC_LIGHTSWITCH,
+                                ChannelFunction.SUPLA_CHANNELFNC_CONTROLLINGTHEGATE),
+                        Optional.empty());
 
         ChannelValue value = decoder.decode(new byte[] {1}, description);
 
@@ -90,7 +99,8 @@ class RelayTypeDecoderTest {
                 new ChannelDescription(
                         ChannelType.SUPLA_CHANNELTYPE_RELAY,
                         Set.of(),
-                        Set.of(BitFunction.SUPLA_BIT_FUNC_THERMOMETER));
+                        List.of(ChannelFunction.SUPLA_CHANNELFNC_THERMOMETER),
+                        Optional.empty());
 
         ChannelValue value = decoder.decode(new byte[] {1}, description);
 
@@ -99,110 +109,100 @@ class RelayTypeDecoderTest {
     }
 
     @Test
-    void allBitFunctionsShouldBeCategorized() {
-        var uncategorized = EnumSet.allOf(BitFunction.class);
-        uncategorized.removeAll(RelayTypeDecoder.supportedSemanticFunctions());
-        uncategorized.removeAll(
-                Set.of(
-                        BitFunction.SUPLA_BIT_FUNC_THERMOMETER,
-                        BitFunction.SUPLA_BIT_FUNC_HUMIDITYANDTEMPERATURE,
-                        BitFunction.SUPLA_BIT_FUNC_HUMIDITY,
-                        BitFunction.SUPLA_BIT_FUNC_WINDSENSOR,
-                        BitFunction.SUPLA_BIT_FUNC_PRESSURESENSOR,
-                        BitFunction.SUPLA_BIT_FUNC_RAINSENSOR,
-                        BitFunction.SUPLA_BIT_FUNC_WEIGHTSENSOR,
-                        BitFunction.SUPLA_BIT_FUNC_HVAC_THERMOSTAT,
-                        BitFunction.SUPLA_BIT_FUNC_HVAC_THERMOSTAT_HEAT_COOL,
-                        BitFunction.SUPLA_BIT_FUNC_HVAC_THERMOSTAT_DIFFERENTIAL,
-                        BitFunction.SUPLA_BIT_FUNC_HVAC_DOMESTIC_HOT_WATER));
+    void semanticRelayValuesShouldBeSupportedFunctions() {
+        var semanticRelayFunctions =
+                semanticRelayValues()
+                        .map(arguments -> (ChannelFunction) arguments.get()[0])
+                        .collect(Collectors.toSet());
 
-        assertThat(uncategorized).isEmpty();
+        assertThat(Set.copyOf(RelayTypeDecoder.supportedSemanticFunctions()))
+                .isEqualTo(semanticRelayFunctions);
     }
 
     static Stream<Arguments> semanticRelayValues() {
         return Stream.of(
                 Arguments.of(
-                        BitFunction.SUPLA_BIT_FUNC_CONTROLLINGTHEGATEWAYLOCK,
+                        ChannelFunction.SUPLA_CHANNELFNC_CONTROLLINGTHEGATEWAYLOCK,
                         GatewayLockValue.UNLOCKED,
                         GatewayLockValue.LOCKED,
                         GatewayLockValue.class),
                 Arguments.of(
-                        BitFunction.SUPLA_BIT_FUNC_CONTROLLINGTHEGATE,
+                        ChannelFunction.SUPLA_CHANNELFNC_CONTROLLINGTHEGATE,
                         GateValue.OPEN,
                         GateValue.CLOSE,
                         GateValue.class),
                 Arguments.of(
-                        BitFunction.SUPLA_BIT_FUNC_CONTROLLINGTHEGARAGEDOOR,
+                        ChannelFunction.SUPLA_CHANNELFNC_CONTROLLINGTHEGARAGEDOOR,
                         GarageDoorValue.OPEN,
                         GarageDoorValue.CLOSE,
                         GarageDoorValue.class),
                 Arguments.of(
-                        BitFunction.SUPLA_BIT_FUNC_CONTROLLINGTHEDOORLOCK,
+                        ChannelFunction.SUPLA_CHANNELFNC_CONTROLLINGTHEDOORLOCK,
                         DoorLockValue.UNLOCKED,
                         DoorLockValue.LOCKED,
                         DoorLockValue.class),
                 Arguments.of(
-                        BitFunction.SUPLA_BIT_FUNC_CONTROLLINGTHEROLLERSHUTTER,
+                        ChannelFunction.SUPLA_CHANNELFNC_CONTROLLINGTHEROLLERSHUTTER,
                         RollerShutterValue.OPEN,
                         RollerShutterValue.CLOSE,
                         RollerShutterValue.class),
                 Arguments.of(
-                        BitFunction.SUPLA_BIT_FUNC_POWERSWITCH,
+                        ChannelFunction.SUPLA_CHANNELFNC_POWERSWITCH,
                         PowerSwitchValue.ON,
                         PowerSwitchValue.OFF,
                         PowerSwitchValue.class),
                 Arguments.of(
-                        BitFunction.SUPLA_BIT_FUNC_LIGHTSWITCH,
+                        ChannelFunction.SUPLA_CHANNELFNC_LIGHTSWITCH,
                         LightSwitchValue.ON,
                         LightSwitchValue.OFF,
                         LightSwitchValue.class),
                 Arguments.of(
-                        BitFunction.SUPLA_BIT_FUNC_STAIRCASETIMER,
+                        ChannelFunction.SUPLA_CHANNELFNC_STAIRCASETIMER,
                         StaircaseTimerValue.ON,
                         StaircaseTimerValue.OFF,
                         StaircaseTimerValue.class),
                 Arguments.of(
-                        BitFunction.SUPLA_BIT_FUNC_CONTROLLINGTHEROOFWINDOW,
+                        ChannelFunction.SUPLA_CHANNELFNC_CONTROLLINGTHEROOFWINDOW,
                         RoofWindowValue.OPEN,
                         RoofWindowValue.CLOSE,
                         RoofWindowValue.class),
                 Arguments.of(
-                        BitFunction.SUPLA_BIT_FUNC_CONTROLLINGTHEFACADEBLIND,
+                        ChannelFunction.SUPLA_CHANNELFNC_CONTROLLINGTHEFACADEBLIND,
                         FacadeBlindValue.OPEN,
                         FacadeBlindValue.CLOSE,
                         FacadeBlindValue.class),
                 Arguments.of(
-                        BitFunction.SUPLA_BIT_FUNC_TERRACE_AWNING,
+                        ChannelFunction.SUPLA_CHANNELFNC_TERRACE_AWNING,
                         TerraceAwningValue.OPEN,
                         TerraceAwningValue.CLOSE,
                         TerraceAwningValue.class),
                 Arguments.of(
-                        BitFunction.SUPLA_BIT_FUNC_PROJECTOR_SCREEN,
+                        ChannelFunction.SUPLA_CHANNELFNC_PROJECTOR_SCREEN,
                         ProjectorScreenValue.OPEN,
                         ProjectorScreenValue.CLOSE,
                         ProjectorScreenValue.class),
                 Arguments.of(
-                        BitFunction.SUPLA_BIT_FUNC_CURTAIN,
+                        ChannelFunction.SUPLA_CHANNELFNC_CURTAIN,
                         CurtainValue.OPEN,
                         CurtainValue.CLOSE,
                         CurtainValue.class),
                 Arguments.of(
-                        BitFunction.SUPLA_BIT_FUNC_VERTICAL_BLIND,
+                        ChannelFunction.SUPLA_CHANNELFNC_VERTICAL_BLIND,
                         VerticalBlindValue.OPEN,
                         VerticalBlindValue.CLOSE,
                         VerticalBlindValue.class),
                 Arguments.of(
-                        BitFunction.SUPLA_BIT_FUNC_ROLLER_GARAGE_DOOR,
+                        ChannelFunction.SUPLA_CHANNELFNC_ROLLER_GARAGE_DOOR,
                         RollerGarageDoorValue.OPEN,
                         RollerGarageDoorValue.CLOSE,
                         RollerGarageDoorValue.class),
                 Arguments.of(
-                        BitFunction.SUPLA_BIT_FUNC_PUMPSWITCH,
+                        ChannelFunction.SUPLA_CHANNELFNC_PUMPSWITCH,
                         PumpSwitchValue.ON,
                         PumpSwitchValue.OFF,
                         PumpSwitchValue.class),
                 Arguments.of(
-                        BitFunction.SUPLA_BIT_FUNC_HEATORCOLDSOURCESWITCH,
+                        ChannelFunction.SUPLA_CHANNELFNC_HEATORCOLDSOURCESWITCH,
                         HeatOrColdSourceSwitchValue.ON,
                         HeatOrColdSourceSwitchValue.OFF,
                         HeatOrColdSourceSwitchValue.class));

--- a/protocol/src/test/java/pl/grzeslowski/jsupla/protocol/api/channeltype/decoders/TimerAbstractDecoderTest.java
+++ b/protocol/src/test/java/pl/grzeslowski/jsupla/protocol/api/channeltype/decoders/TimerAbstractDecoderTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.time.Duration;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
+import pl.grzeslowski.jsupla.protocol.api.ChannelFunction;
 import pl.grzeslowski.jsupla.protocol.api.ChannelType;
 import pl.grzeslowski.jsupla.protocol.api.channeltype.value.TimerValue;
 import pl.grzeslowski.jsupla.protocol.api.consts.ProtoConsts;
@@ -47,6 +48,11 @@ class TimerAbstractDecoderTest {
 
         @Override
         public Set<ChannelType> supportedChannelValueTypes() {
+            return Set.of();
+        }
+
+        @Override
+        public Set<ChannelFunction> supportedChannelFunctions() {
             return Set.of();
         }
     }


### PR DESCRIPTION
## Summary
- add ChannelFunction-based channel descriptions and explicit funcList/defaultValue mapping
- resolve channel value decoders by selected function, single unambiguous function, then channel type
- move semantic relay parsing to ChannelFunction and cover fallback behavior in tests

## Verification
- ./gradlew check
- ./gradlew publishToMavenLocal